### PR TITLE
SPR-15543: Fix duplicate subscriptionId for destination-sessionId key

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -219,7 +219,7 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 		return readJavaType(javaType, inputMessage);
 	}
 
-	private Object readJavaType(JavaType javaType, HttpInputMessage inputMessage) throws IOException {
+	private Object readJavaType(JavaType javaType, HttpInputMessage inputMessage) {
 		try {
 			if (inputMessage instanceof MappingJacksonInputMessage) {
 				Class<?> deserializationView = ((MappingJacksonInputMessage) inputMessage).getDeserializationView();
@@ -232,6 +232,9 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 		}
 		catch (JsonProcessingException ex) {
 			throw new HttpMessageNotReadableException("JSON parse error: " + ex.getOriginalMessage(), ex);
+		}
+		catch (IOException ex) {
+			throw new HttpMessageNotReadableException("I/O error while reading input message", ex);
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/xml/MappingJackson2XmlHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/xml/MappingJackson2XmlHttpMessageConverterTests.java
@@ -17,7 +17,6 @@
 package org.springframework.http.converter.xml;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -27,11 +26,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.MockHttpInputMessage;
 import org.springframework.http.MockHttpOutputMessage;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.json.MappingJacksonValue;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -102,7 +100,7 @@ public class MappingJackson2XmlHttpMessageConverterTests {
 				outputMessage.getHeaders().getContentType());
 	}
 
-	@Test(expected = IOException.class)
+	@Test(expected = HttpMessageNotReadableException.class)
 	public void readInvalidXml() throws IOException {
 		String body = "FooBar";
 		MockHttpInputMessage inputMessage = new MockHttpInputMessage(body.getBytes("UTF-8"));
@@ -129,7 +127,7 @@ public class MappingJackson2XmlHttpMessageConverterTests {
 
 		MappingJacksonValue jacksonValue = new MappingJacksonValue(bean);
 		jacksonValue.setSerializationView(MyJacksonView1.class);
-		this.writeInternal(jacksonValue, outputMessage);
+		this.converter.write(jacksonValue, null, outputMessage);
 
 		String result = outputMessage.getBodyAsString(Charset.forName("UTF-8"));
 		assertThat(result, containsString("<withView1>with</withView1>"));
@@ -154,7 +152,7 @@ public class MappingJackson2XmlHttpMessageConverterTests {
 		MockHttpInputMessage inputMessage = new MockHttpInputMessage(body.getBytes("UTF-8"));
 		inputMessage.getHeaders().setContentType(new MediaType("application", "xml"));
 
-		this.thrown.expect(IOException.class);
+		this.thrown.expect(HttpMessageNotReadableException.class);
 		this.converter.read(MyBean.class, inputMessage);
 	}
 
@@ -181,16 +179,8 @@ public class MappingJackson2XmlHttpMessageConverterTests {
 		MockHttpInputMessage inputMessage = new MockHttpInputMessage(body.getBytes("UTF-8"));
 		inputMessage.getHeaders().setContentType(new MediaType("application", "xml"));
 
-		this.thrown.expect(IOException.class);
+		this.thrown.expect(HttpMessageNotReadableException.class);
 		this.converter.read(MyBean.class, inputMessage);
-	}
-
-
-	private void writeInternal(Object object, HttpOutputMessage outputMessage) throws Exception {
-		Method method = AbstractHttpMessageConverter.class.getDeclaredMethod(
-				"writeInternal", Object.class, HttpOutputMessage.class);
-		method.setAccessible(true);
-		method.invoke(this.converter, object, outputMessage);
 	}
 
 


### PR DESCRIPTION
DefaultSubscriptionRegistry's destinationCache accessCache contains duplicate subscriptionId for destination - sessionId key if findSubscriptions is called after addSubscription and before updateAfterNewSubscription.

The change includes checking for existing subId  in updateAfterNewSubscription method before adding subId value to sessionId key. (Set implementation to avoid duplication can be considered or other better solutions are appreciated).

Issue: SPR-15492

I have submitted CLA.